### PR TITLE
bump to version 2.1.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '2.1.14' %}
+{% set version = '2.1.18' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -14,7 +14,7 @@ source:
     - https://cran.r-project.org/src/contrib/Archive/yaml/yaml_{{ version }}.tar.gz
 
 
-  sha256: 41a559846f6d44cc2dbcb3fc0becbc50d2766d3dc2aad7cfb97c1f9759ec0875
+  sha256: 1bb54d5f28f0adc24a5f3cfbf5cda4a71ca2ad7922a687f756e0619767c1a496
 
 build:
   number: 0
@@ -44,8 +44,7 @@ test:
 about:
   home: https://CRAN.R-project.org/package=yaml
   license: BSD_3_clause
-  summary: Implements the 'libyaml' 'YAML' 1.1 parser and emitter (<http://pyyaml.org/wiki/LibYAML>)
-    for R.
+  summary: Implements the 'libyaml' 'YAML' 1.1 parser and emitter (<http://pyyaml.org/wiki/LibYAML>) for R.
   license_family: BSD
   license_file: LICENSE
 
@@ -54,3 +53,8 @@ about:
 extra:
   recipe-maintainers:
     - croth1
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - bsennblad

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,9 @@ requirements:
     - posix                # [win]
     - {{native}}toolchain  # [win]
     - gcc                  # [not win]
-
   run:
     - r-base
+    - libgcc               # [not win]
 
 test:
   commands:


### PR DESCRIPTION
Updated to version 2.1.18. This seems to fix an error checking bug regarding number conversions (this was implemented already in yaml 2.1.16; r-yaml 2.1.16 is available through the r-channel, but not compatible with many conda-forge packages:(

Recipe created by first using conda_r_skeleton_helper, comparing with current recipe and copying relevant fields. The following build requirement in the skeleton metayaml was not present in current meta.yaml,
 - libgcc  # [not win]
I chose to include it in the update, nevertheless. Hopefully, this was the right choice.

notifying maintainers:
@croth1 
@jdblischak 
@johanneskoester 
@daler 
@bgruening 
